### PR TITLE
Update data_h5.jl

### DIFF
--- a/src/data_h5.jl
+++ b/src/data_h5.jl
@@ -113,7 +113,10 @@ function export_jld2_h5(path_data_dict::String; path_h5::Union{String,Nothing}=n
         g2["velocity"] = velocity_filter ? velocity_filt : velocity
         g2["reversal_vec"] = reversal_vec
         g2["reversal_events"] = reversal_events
+        g2["pumping"] = ones(size(velocity)) .* -9999  # supply an unrealistic value to make yet-to-be-annotated datasets available on flv-utils
 
+        # if pumping is not found in data_dict, the default unrealistic value will be kept
+        # if pumping is found in data_dict, the actual value will overwrite the unrealistic default
         list_key = ["head_angle", "angular_velocity", "pumping", "worm_curvature", "worm_angle",
             "body_angle_absolute", "body_angle_all", "body_angle", "zeroed_x_confocal", "zeroed_y_confocal"]
         for k = list_key


### PR DESCRIPTION
Allow ANTSUN users to export `data_dict.jld2` to `processed_h5` even before they finish pumping annotation, which sometimes only happen months after dataset finishes processing on ANTSUN.

When `pumping` is not found as a key in `data_dict.jld2`, a default vector of `[-9999, ..., -9999]` will be used.

Users can come back and remake `processed_h5` after they finish annotating pumping and adding it to `data_dict.jld2` by running the same code. Currently JLD2 files are very prone to corruption with repeated read/write. This pull request is meant to minimize the delay between ANTSUN processing, making `processed_h5` and uploading them to `flv_utils`, which a lot of other analysis libraries will be pulling datasets off of.